### PR TITLE
Create convert_day.py

### DIFF
--- a/convert_day.py
+++ b/convert_day.py
@@ -1,0 +1,91 @@
+from datetime import datetime
+
+def IsLeapYear(year):
+    """Check if a year is a leap year."""
+    return (year % 4 == 0) and ((year % 100 != 0) or (year % 400 == 0))
+
+def ConvertDayToTimestamp(day, month, year):
+    """
+    Convert a given day (e.g., 01/01/2025) with defaul time 00:00:00 
+    into a Unix timestamp (e.g., 1735743797).
+    Input: day, month, year (integers).
+    Output: timestamp (in seconds), error message (if any).
+    """
+
+    if not(isinstance(year, int) and isinstance(month, int) and isinstance(day, int)):
+        return 0, "Invalid input: Input year, month and day must be intergers."
+    if year <= 1970:
+        return 0, "Invalid input: The year must be 1971 or later."
+    if (month < 1) or (month > 12):
+        return 0, "Invalid input: The month must be between 1 and 12."
+
+    if day < 1: 
+        return 0, "Invalid input: The day must be greater than 0"
+    if (month in {1, 3, 5, 7, 8, 10, 12}) and (day > 31):
+        return 0, f"Invalid input: The month {month} only has 31 days."
+    if (month in {4, 6, 9, 11}) and (day > 30):
+        return 0, f"Invalid input: The month {month} only has 30 days."
+    
+    if IsLeapYear(year):
+        if (month == 2) and (day > 29):
+            return 0, f"Invalid input: February {year} (Leap year) only has 29 days."
+    elif (month == 2) and (day > 28):
+        return 0, f"Invalid input day. February {year} (Common year) only has 28 days." 
+    
+    dt = datetime(year, month, day, 0, 0) 
+    unixTimestamp = int(dt.timestamp())
+    err = None
+
+    return unixTimestamp, err
+
+def GetMonthRange(month, year):
+    """
+    Calculate the Unix timestamp range for a given month of a year.
+    Input: month, year (integers).
+    Output: 
+        startOfMonth (int): Unix timestamp for the start of the month (00:00:00 on the 1st day).
+        endOfMonth (int): Unix timestamp for the end of the month (23:59:59 on the last day).
+        err (str or None): An error message if input is invalid, or None if no errors.
+    """
+    if not(isinstance(year, int) and isinstance(month, int)):
+        return 0, 0, "Invalid input: Input year and month must be intergers."
+
+    # Calculate the start of the month
+    startOfMonth, err1 = ConvertDayToTimestamp(1, month, year)
+    if err1:
+        return startOfMonth, 0, err1
+
+    # Calculate the start of the next month
+    if month == 12:
+        endOfMonth, err2 = ConvertDayToTimestamp(1, 1, year + 1)
+    else:
+        endOfMonth, err2 = ConvertDayToTimestamp(1, month + 1, year)
+    endOfMonth -= 1 if endOfMonth > 0 else 0 # Adjust to the end of the month (from 00:00:00 of 01/mm + 1/yyyy to 23:59:59 of dd/mm/yyyy)
+
+    err = err1 if err1 == err2 else err2 or err1 or f"{err1}; {err2}"
+
+    return startOfMonth, endOfMonth, err
+
+def GetYearRange(year):
+    """
+    Calculate the Unix timestamp range for a given year.
+    Input: year (integers).
+    Output: 
+        startOfYear (int): Unix timestamp for the start of the year (00:00:00 on 01/01/year).
+        endOfYear (int): Unix timestamp for the end of the month (23:59:59 on 31/12/year).
+        err (str or None): An error message if input is invalid, or None if no errors.
+    """
+    if not(isinstance(year, int)):
+        return 0, 0, "Invalid input: Input year must be interger."
+
+    # Calculate the start of the year
+    startOfYear, err1 = ConvertDayToTimestamp(1, 1, year)
+    if err1:
+        return startOfYear, 0, err1
+    
+    # Calculate the start of the next year
+    endOfYear, err2 = ConvertDayToTimestamp(1, 1, year + 1)
+    endOfYear -= 1 if endOfYear > 0 else 0 # Adjust to 31st December 23:59:59
+    err = err1 if err1 == err2 else err2 or err1 or f"{err1}; {err2}"
+
+    return startOfYear, endOfYear, err

--- a/convert_day.py
+++ b/convert_day.py
@@ -4,7 +4,7 @@ def isLeapYear(year: int) -> bool:
     """Check if a year is a leap year."""
     return (year % 4 == 0) and ((year % 100 != 0) or (year % 400 == 0))
 
-def ConvertDayToTimestamp(day, month, year):
+def ConvertDayToTimestamp(day: int, month: int, year: int) -> tuple[int, str]:
     """
     Convert a given day (e.g., 01/01/2025) with defaul time 00:00:00 
     into a Unix timestamp (e.g., 1735743797).
@@ -12,8 +12,6 @@ def ConvertDayToTimestamp(day, month, year):
     Output: timestamp (in seconds), error message (if any).
     """
 
-    if not(isinstance(year, int) and isinstance(month, int) and isinstance(day, int)):
-        return 0, "Invalid input: Input year, month and day must be intergers."
     if year <= 1970:
         return 0, "Invalid input: The year must be 1971 or later."
     if (month < 1) or (month > 12):
@@ -38,7 +36,7 @@ def ConvertDayToTimestamp(day, month, year):
 
     return unixTimestamp, err
 
-def GetMonthRange(month, year):
+def GetMonthRange(month: int, year: int) -> tuple[int, int, str]:
     """
     Calculate the Unix timestamp range for a given month of a year.
     Input: month, year (integers).
@@ -47,8 +45,6 @@ def GetMonthRange(month, year):
         endOfMonth (int): Unix timestamp for the end of the month (23:59:59 on the last day).
         err (str or None): An error message if input is invalid, or None if no errors.
     """
-    if not(isinstance(year, int) and isinstance(month, int)):
-        return 0, 0, "Invalid input: Input year and month must be intergers."
 
     # Calculate the start of the month
     startOfMonth, err1 = ConvertDayToTimestamp(1, month, year)
@@ -66,7 +62,7 @@ def GetMonthRange(month, year):
 
     return startOfMonth, endOfMonth, err
 
-def GetYearRange(year):
+def GetYearRange(year: int) -> tuple[int, int, str]:
     """
     Calculate the Unix timestamp range for a given year.
     Input: year (integers).
@@ -75,8 +71,6 @@ def GetYearRange(year):
         endOfYear (int): Unix timestamp for the end of the month (23:59:59 on 31/12/year).
         err (str or None): An error message if input is invalid, or None if no errors.
     """
-    if not(isinstance(year, int)):
-        return 0, 0, "Invalid input: Input year must be interger."
 
     # Calculate the start of the year
     startOfYear, err1 = ConvertDayToTimestamp(1, 1, year)

--- a/convert_day.py
+++ b/convert_day.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-def IsLeapYear(year):
+def isLeapYear(year: int) -> bool:
     """Check if a year is a leap year."""
     return (year % 4 == 0) and ((year % 100 != 0) or (year % 400 == 0))
 
@@ -26,7 +26,7 @@ def ConvertDayToTimestamp(day, month, year):
     if (month in {4, 6, 9, 11}) and (day > 30):
         return 0, f"Invalid input: The month {month} only has 30 days."
     
-    if IsLeapYear(year):
+    if isLeapYear(year):
         if (month == 2) and (day > 29):
             return 0, f"Invalid input: February {year} (Leap year) only has 29 days."
     elif (month == 2) and (day > 28):


### PR DESCRIPTION
_Dear @capigiba and all concerned,_

The `convert_day.py` module provides four functions: `IsLeapYear(year)`, `ConvertDayToTimestamp(day, month, year)`, `GetMonthRange(month, year)`, and `GetYearRange(year)`.

1. `IsLeapYear(year)` determines if a year is a leap year based on divisibility rules: divisible by 4 but not 100, unless also divisible by 400.

2. `ConvertDayToTimestamp(day, month, year)` converts a date (e.g., 01/01/2025) to a Unix timestamp (e.g., 1735743797) with a default time of 00:00:00. It checks:
   - If inputs are integers; otherwise, it returns 0 and an error message.
   - If the `year`, `month`, and `day` are valid for the given date, based on leap year rules.
   - If valid, it returns the timestamp and `None` for errors.

3. `GetMonthRange(month, year)` calculates the Unix timestamps for the start and end of a month:
   - Validates `month` and `year` as integers.
   - Uses `ConvertDayToTimestamp` to get the start of the month. If invalid, returns an error.
   - Calculates the end of the month by finding the start of the next month, then subtracting 1 second to get the last moment of the current month.
   - Returns the start, end timestamps, and any error messages.

4. `GetYearRange(year)` calculates the Unix timestamps for the start and end of a year:
   - Validates `year` as an integer.
   - Gets the start of the year using `ConvertDayToTimestamp`. If invalid, returns an error.
   - Finds the end of the year by calculating the start of the next year and subtracting 1 second.
   - Returns the start, end timestamps, and any error messages.

The test cases check the accuracy and stability of the `convert_day.py` functions, ensuring they return correct Unix timestamps for valid inputs, handle invalid inputs (e.g., non-integers, out-of-range dates) with appropriate errors, and manage edge cases like leap years without crashing. The attached screenshot shows test scenarios for both valid and invalid inputs.

![image](https://github.com/user-attachments/assets/ed9a82b1-1c3d-47fe-b5d3-ee0badf47922)
![image](https://github.com/user-attachments/assets/374bb60c-a134-4c57-8d63-645657072c15)

_Best regards,_
Hita.